### PR TITLE
Standard property resolution

### DIFF
--- a/client-interfaces/pom.xml
+++ b/client-interfaces/pom.xml
@@ -8,4 +8,26 @@
   <artifactId>prog-mgmnt-client-interfaces</artifactId>
   <name>Smarter Balanced #11 Program Management - Client Interfaces</name>
   <description>Interfaces for the Program Management Client</description>
+
+  <profiles>
+    <profile>
+      <id>release</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-source-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>attach-sources</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/client-interfaces/src/main/java/org/opentestsystem/shared/progman/init/ProgManRetriever.java
+++ b/client-interfaces/src/main/java/org/opentestsystem/shared/progman/init/ProgManRetriever.java
@@ -39,7 +39,7 @@ public class ProgManRetriever {
     @Autowired(required=false)
     private ProgManClient progManClient;
 
-    @Value("#{systemProperties['progman.locator']}")
+    @Value("${progman.locator}")
     private String locator = "";
 
     /**

--- a/client-null-impl/pom.xml
+++ b/client-null-impl/pom.xml
@@ -17,5 +17,26 @@
         </dependency>
        
     </dependencies>
-    
+
+    <profiles>
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -43,4 +43,26 @@
         </dependency>
     </dependencies>
 
+    <profiles>
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -174,6 +174,24 @@
 
 	</dependencies>
 
+	<build>
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-source-plugin</artifactId>
+					<version>${maven-source-plugin.version}</version>
+				</plugin>
+			</plugins>
+		</pluginManagement>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-release-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+
 	<distributionManagement>
 		<repository>
 			<id>central</id>


### PR DESCRIPTION
This PR changes the progman.locator property to use Spring-standard property resolution rather than requiring the value to be defined as a system property.

I also took this opportunity to create/release source jars during the release process.